### PR TITLE
Fixed the specific query

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ require([
   "esri/tasks/support/Query",
   "esri/symbols/SimpleMarkerSymbol",
   "esri/core/watchUtils",
-  "./QueryLib.js"
+  "./testQueryLibs.js"
 ], function(
   SketchViewModel,
   Polyline,
@@ -184,6 +184,12 @@ require([
       view.ui.add(compassWidget, "top-left");
       view.ui.add(toggle, "bottom-right");
       view.ui.add(legendExpand, "bottom-right");
+
+      // Call doQuery() each time the button is clicked
+      // view.Accpane3.add("optionsDiv"); // Dario: Do we need this?
+      document.getElementById("doBtn").addEventListener("click", function () {
+        QueryLib.executeSpecificQuery(view);
+      });
     });
 
     // Close the 'help' popup when view is focused

--- a/index.js
+++ b/index.js
@@ -268,7 +268,8 @@ require([
     bufferGraphic.geometry = buffer;
 
     // Query total beds and beds occupied
-    QueryLib.queryLayerViewAgeStats(featureLayerView, buffer).then(function(
+    QueryLib.buffer = buffer;
+    QueryLib.queryLayerViewAgeStats(featureLayerView).then(function(
       newData
     ) {
       // Create a chart from the returned result

--- a/testQueryLibs.js
+++ b/testQueryLibs.js
@@ -1,4 +1,4 @@
-define([], function() {
+define(["esri/layers/GraphicsLayer", "esri/tasks/QueryTask", "esri/tasks/support/Query"], function(GraphicsLayer, QueryTask, Query) {
   // Private members
   // Set up statistics definition for client-side query
   //This is for the attribute query
@@ -36,93 +36,22 @@ define([], function() {
       }
     ]
   };
-  var resultsLayer = new GraphicsLayer();
-
-  var qTask = new QueryTask({
-    url:
-      "https://services.arcgis.com/o6oETlrWetREI1A2/arcgis/rest/services/Hospital_LL/FeatureServer",
-    outFields: ["*"]
-  });
-
-  var params = new Query({
-    returnGeometry: true,
-    outFields: ["*"]
-  });
-
- // Call doQuery() each time the button is clicked 
-  view.when(function() {
-    view.Accpane3.add("optionsDiv");
-    document.getElementById("doBtn").addEventListener("click", doQuery);
-  });
-
-  var attributeName = document.getElementById("attSelect");
-  var expressionSign = document.getElementById("signSelect");
-  var value = document.getElementById("valSelect");
-
-    // Executes each time the button is clicked
-  function doQuery() {
-    // Clear the results from a previous query
-  resultsLayer.removeAll();
-
-  params.where =
-      attributeName.value + expressionSign.value + value.value;
-
-    // executes the query and calls getResults() once the promise is resolved
-    // promiseRejected() is called if the promise is rejected
-    qTask
-      .execute(params)
-      .then(getResults)
-      .catch(promiseRejected);
-  }
-
-  // Called each time the promise is resolved
-  function getResults(response) {
-    // Loop through each of the results and assign a symbol and PopupTemplate
-    // to each so they may be visualized on the map
-    var hospResults = response.features.map(function(feature) {
-      feature.symbol = {
-        type: "simple-marker",
-        style: "circle",
-        color: "blue",
-        size: "8px", // pixels
-        outline: {
-          color: [124, 11, 11],
-          width: 2 // points
-        }
-      };
-      feature.popupTemplate = popupTemplate;
-      return feature;
-    });
-
-    resultsLayer.addMany(hospResults);
-
-    // animate to the results after they are added to the map
-    view.goTo(hospResults).then(function() {
-      view.popup.open({
-        features: hospResults,
-        featureMenuOpen: true,
-        updateLocationEnabled: true
-      });
-    });
-
-    // print the number of results returned to the user
-    document.getElementById("printResults").innerHTML =
-      hospResults.length + " results found!";
-  }
 
   // Called each time the promise is rejected
   function promiseRejected(error) {
     console.error("Promise rejected: ", error.message);
   }
-});
-//This is for the specific Query on the fly 
-const statDefinitions = ["Hosp_beds", "Occupency"].map(function(fieldName) {
+
+  //This is for the specific Query on the fly 
+  const statDefinitions = ["Hosp_beds", "Occupency"].map(function(fieldName) {
     return {
       onStatisticField: fieldName,
       outStatisticFieldName: fieldName + "_TOTAL",
       statisticType: "sum"
     };
   });
+
+  var resultsLayer = new GraphicsLayer();
 
   // Public (exported) members
   return {
@@ -159,6 +88,81 @@ const statDefinitions = ["Hosp_beds", "Occupency"].map(function(fieldName) {
         .catch(function(error) {
           console.log(error);
         });
+    },
+
+    resultsLayer: resultsLayer,
+
+    executeSpecificQuery(view) {
+      var qTask = new QueryTask({
+        url:
+          "https://services.arcgis.com/o6oETlrWetREI1A2/arcgis/rest/services/Hospital_LL/FeatureServer/0",
+        outFields: ["*"]
+      });
+    
+      var params = new Query({
+        returnGeometry: true,
+        outFields: ["*"]
+      });
+    
+      var attributeName = document.getElementById("attSelect");
+      var expressionSign = document.getElementById("signSelect");
+      var value = document.getElementById("valSelect");
+    
+      // Executes each time the button is clicked
+      function doQuery() {
+        // Clear the results from a previous query
+        resultsLayer.removeAll();
+      
+        params.where =
+            attributeName.value + expressionSign.value + value.value;
+      
+          // executes the query and calls getResults() once the promise is resolved
+          // promiseRejected() is called if the promise is rejected
+          qTask
+            .execute(params)
+            .then(getResults)
+            .catch(promiseRejected);
+      }
+      
+      // Called each time the promise is resolved
+      function getResults(response) {
+        console.log("response", response);
+        // Loop through each of the results and assign a symbol and PopupTemplate
+        // to each so they may be visualized on the map
+        var hospResults = response.features.map(function(feature) {
+          feature.symbol = {
+            type: "simple-marker",
+            style: "circle",
+            color: "blue",
+            size: "8px", // pixels
+            outline: {
+              color: [124, 11, 11],
+              width: 2 // points
+            }
+          };
+          feature.popupTemplate = popupTemplate;
+          return feature;
+        });
+    
+        resultsLayer.addMany(hospResults);
+
+        console.log("GOTO")
+    
+        // animate to the results after they are added to the map
+        view.goTo(hospResults).then(function() {
+          view.popup.open({
+            features: hospResults,
+            featureMenuOpen: true,
+            updateLocationEnabled: true
+          });
+        });
+    
+        // print the number of results returned to the user
+        document.getElementById("printResults").innerHTML =
+          hospResults.length + " results found!";
+      }
+
+      doQuery();
     }
   };
 });

--- a/testQueryLibs.js
+++ b/testQueryLibs.js
@@ -55,8 +55,10 @@ define(["esri/layers/GraphicsLayer", "esri/tasks/QueryTask", "esri/tasks/support
 
   // Public (exported) members
   return {
+    buffer: null,
+
     //Spatial query for hospital feature layer view for statistics
-    queryLayerViewAgeStats(featureLayerView, buffer) {
+    queryLayerViewAgeStats(featureLayerView) {
       // Data storage for the chart
       let Hosp_beds = [],
         Occupency = [];
@@ -65,7 +67,7 @@ define(["esri/layers/GraphicsLayer", "esri/tasks/QueryTask", "esri/tasks/support
       // Get the total bed count and beds occupied for the hospitals
       const query = featureLayerView.layer.createQuery();
       query.outStatistics = statDefinitions;
-      query.geometry = buffer;
+      query.geometry = this.buffer;
 
       // Query the features on the client using FeatureLayerView.queryFeatures
       return featureLayerView
@@ -101,7 +103,8 @@ define(["esri/layers/GraphicsLayer", "esri/tasks/QueryTask", "esri/tasks/support
     
       var params = new Query({
         returnGeometry: true,
-        outFields: ["*"]
+        outFields: ["*"],
+        geometry: this.buffer
       });
     
       var attributeName = document.getElementById("attSelect");


### PR DESCRIPTION
This PR rewires the attribute query. It is implemented in `testQueryLibs.js` and accessed from `index.js` through `QueryLib.executeSpecificQuery(view)`. The attribute query is now sensitive to the input geometry (i.e. the buffer circle).
